### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: cachix/install-nix-action@v24
+      - uses: cachix/install-nix-action@v25
         with:
           nix_path: nixpkgs=channel:nixos-22.11
           extra_nix_config: "system-features = nixos-test benchmark big-parallel kvm"
-      - uses: cachix/cachix-action@v13
+      - uses: cachix/cachix-action@v14
         with:
           name: timhae-firefly
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: cachix/install-nix-action@v24
+      - uses: cachix/install-nix-action@v25
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[cachix/install-nix-action](https://github.com/cachix/install-nix-action)** published a new release **[v25](https://github.com/cachix/install-nix-action/releases/tag/v25)** on 2024-01-12T17:20:59Z
* **[cachix/cachix-action](https://github.com/cachix/cachix-action)** published a new release **[v14](https://github.com/cachix/cachix-action/releases/tag/v14)** on 2024-01-12T13:29:22Z
