### PR TITLE
Changed user setup to work without nginx

### DIFF
--- a/module/firefly-iii.nix
+++ b/module/firefly-iii.nix
@@ -433,6 +433,7 @@ in
           inherit group;
           isSystemUser = true;
         };
+      } // mkIf config.services.nginx.enable {
         "${config.services.nginx.user}".extraGroups = [ group ];
       };
       groups = mkIf (group == defaultGroup) {

--- a/module/firefly-iii.nix
+++ b/module/firefly-iii.nix
@@ -396,7 +396,7 @@ in
           fireflyEnv = pkgs.writeText "firefly-iii.env" (fireflyEnvVars filteredConfig);
         in
         ''
-          set -euo pipefail
+          set -exuo pipefail
           umask 077
 
           # create the .env file
@@ -428,14 +428,19 @@ in
 
     # User management
     users = {
-      users = mkIf (user == defaultUser) {
-        ${defaultUser} = {
-          inherit group;
-          isSystemUser = true;
-        };
-      } // mkIf config.services.nginx.enable {
-        "${config.services.nginx.user}".extraGroups = [ group ];
-      };
+      users = mkMerge [
+        (mkIf (user == defaultUser) (
+          {
+            ${defaultUser} = {
+              inherit group;
+              isSystemUser = true;
+            };
+          }
+        ))
+        (mkIf config.services.nginx.enable {
+            "${config.services.nginx.user}".extraGroups = [ group ];
+        })
+      ];
       groups = mkIf (group == defaultGroup) {
         ${defaultGroup} = { };
       };


### PR DESCRIPTION
Previously, this module is written assuming the system uses Nginx as its reverse proxy. With a small change, evaluation will at least _not fail_ when nginx is disabled. The user is still responsible for setting up their own reverse proxy though, if they disable nginx.