### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: cachix/install-nix-action@v25
+      - uses: cachix/install-nix-action@v26
         with:
           nix_path: nixpkgs=channel:nixos-22.11
           extra_nix_config: "system-features = nixos-test benchmark big-parallel kvm"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: cachix/install-nix-action@v25
+      - uses: cachix/install-nix-action@v26
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
       - run: nix flake update
-      - uses: peter-evans/create-pull-request@v6.0.0
+      - uses: peter-evans/create-pull-request@v6.0.1
         with:
           commit-message: "chore(deps): update flake inputs"
           title: "chore(deps): update flake inputs"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[cachix/install-nix-action](https://github.com/cachix/install-nix-action)** published a new release **[v26](https://github.com/cachix/install-nix-action/releases/tag/v26)** on 2024-03-08T04:08:21Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v6.0.1](https://github.com/peter-evans/create-pull-request/releases/tag/v6.0.1)** on 2024-02-28T00:33:43Z
