### PR TITLE
Automate patching composer-env.nix in update.sh

### DIFF
--- a/pkgs/composer-env.nix
+++ b/pkgs/composer-env.nix
@@ -190,7 +190,7 @@ let
         ${lib.optionalString (!noDev) (bundleDependencies devPackages)}
         cd ..
 
-        echo "APP_KEY=SomeRandomStringOf32CharsExactly" > .env
+        echo 'APP_KEY=SomeRandomStringOf32CharsExactly' > .env
 
         # Reconstruct autoload scripts
         # We use the optimize feature because Nix packages cannot change after they have been built


### PR DESCRIPTION
`composer-env.nix` has to be patched because we need to somehow set the `APP_KEY` in order to continue with installation. This PR automatically patches `composer-env.nix` with `sed`. It also introduces more debugging output for debugging the script.